### PR TITLE
Typo fix: 'Spotter' => 'Spotted'

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -3,7 +3,7 @@
     link: /blog
   - name: Trek Pack
     link: /trek-pack
-  - name: Spotter a Trekker?
+  - name: Spotted a Trekker?
     link: /subscribe
   - name: Become a Trekker
     link: /loan


### PR DESCRIPTION
Noticed a typo in the footer.  (edited directly via github)